### PR TITLE
Fixing NameError with Sprockets

### DIFF
--- a/lib/sinatra/sprockets.rb
+++ b/lib/sinatra/sprockets.rb
@@ -1,3 +1,4 @@
+require "sprockets"
 require "sinatra/sprockets/version"
 require "sinatra/sprockets/asset_paths"
 require "sinatra/sprockets/configuration"


### PR DESCRIPTION
Following the instructions in the readme, I get a NameError when registering `Sinatra::Sprockets` from the following line in `sinatra/sprockets.rb`:

``` ruby
 @environment = ::Sprockets::Environment.new app.root
```

Fixed this by requiring Sprockets.
